### PR TITLE
Add ActionButton component with styles

### DIFF
--- a/src/components/ActionButton/ActionButton.module.css
+++ b/src/components/ActionButton/ActionButton.module.css
@@ -1,0 +1,23 @@
+.actionButton {
+  width: 14rem;
+  height: 2.25rem;
+  flex-shrink: 0;
+  border-radius: 0.5rem;
+  border: 1px solid #262626;
+  color: #000;
+  font-family: "SF Pro";
+  font-size: var(--font-size-m);
+  font-style: normal;
+  font-weight: 590;
+  line-height: normal;
+}
+
+.dark {
+  background: #121212;
+  color: var(--font-color-light);
+}
+
+.light {
+  background: #fff;
+  color: #000;
+}

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,0 +1,24 @@
+import styles from "./ActionButton.module.css";
+
+type ButtonColor = "dark" | "light";
+
+type ActionButtonProps = {
+  color?: ButtonColor;
+  onClick?: () => void; // Future click function
+  children: string;
+};
+
+export default function ActionButton({
+  color = "light",
+  onClick = () => {},
+  children,
+}: ActionButtonProps) {
+  return (
+    <button
+      className={`${styles.actionButton} ${styles[color]}`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
Introduces a reusable ActionButton React component supporting 'dark' and 'light' color themes, along with corresponding CSS module styles.

DB plz :)