### PR TITLE
Add InputField component with styles

### DIFF
--- a/src/components/InputField/InputField.module.css
+++ b/src/components/InputField/InputField.module.css
@@ -1,0 +1,34 @@
+.inputFieldContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.375rem;
+  align-self: stretch;
+}
+
+.inputField {
+  border-radius: 0.5rem;
+  border: 1px solid #262626;
+  background: #121212;
+  width: 24.3125rem;
+  height: 2.125rem;
+}
+
+.inputFieldContainer label {
+  color: var(--font-color-grey);
+  font-family: "SF Pro";
+  font-size: var(--font-size-m);
+  font-style: normal;
+  font-weight: 510;
+  line-height: normal;
+  margin-bottom: 0.625rem;
+}
+
+.inputFieldContainer p {
+  color: var(--font-color-grey);
+  font-family: "SF Pro";
+  font-size: var(--font-size-s);
+  font-style: normal;
+  font-weight: 510;
+  line-height: normal;
+}

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,0 +1,16 @@
+import styles from "./InputField.module.css";
+
+type InputFieldProps = {
+  text: string;
+  label: string;
+};
+
+export default function InputField({ label, text }: InputFieldProps) {
+  return (
+    <div className={styles.inputFieldContainer}>
+      <label>{label}</label>
+      <input className={styles.inputField} type="text"></input>
+      <p>{text}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduced a new InputField React component and its associated CSS module for consistent input styling and labeling. This component accepts a label and text prop for flexible usage.

DB plz